### PR TITLE
Add WPML-aware language detection

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -7,7 +7,7 @@ Tags:
 Requires at least: 
 Tested up to: 
 Requires PHP: 
-Stable tag: 1.0.0
+Stable tag: 1.0.1
 License: GPLv2
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -56,6 +56,9 @@ An answer to that question.
 4. Click on `Activate plugin`
 
 == Changelog ==
+
+= 1.0.1: September 24, 2025 =
+* Improve compatibility with multilingual forms by detecting the correct language when redirecting donors to JCC.
 
 = 1.0.0: January 16, 2024 =
 * Birthday of JCC Gateway For GiveWP


### PR DESCRIPTION
## Summary
- determine the language code sent to JCC from the GiveWP form so WPML translations redirect with the correct locale
- replace the hard-coded gateway language usage during checkout with the dynamic helper
- bump the plugin version to 1.0.1 and document the change in the readme

## Testing
- php -l jcc-gateway-for-givewp.php

------
https://chatgpt.com/codex/tasks/task_e_68d3d879edc08327ad3d08dae6854e41