### PR TITLE
Fix currency handling for JCC GiveWP gateway

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -7,7 +7,7 @@ Tags:
 Requires at least: 
 Tested up to: 
 Requires PHP: 
-Stable tag: 1.0.1
+Stable tag: 1.0.2
 License: GPLv2
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -56,6 +56,10 @@ An answer to that question.
 4. Click on `Activate plugin`
 
 == Changelog ==
+
+= 1.0.2: September 24, 2025 =
+* Prevent fatal errors in GiveWP 3.0+ by always storing a valid currency code with JCC donations and normalising incoming form data.
+* Automatically backfill the currency for historical JCC donations that were saved without a currency value.
 
 = 1.0.1: September 24, 2025 =
 * Improve compatibility with multilingual forms by detecting the correct language when redirecting donors to JCC.


### PR DESCRIPTION
## Summary
- ensure the gateway always records a currency code by normalising request data and setting the proper donation mode
- add a one-time backfill to update historical JCC donations with missing currency values
- bump the plugin version and changelog to 1.0.2

## Testing
- php -l jcc-gateway-for-givewp.php

------
https://chatgpt.com/codex/tasks/task_e_68d3e6eeb9e883278f34ef1c83da07a6